### PR TITLE
Link to the external source of the page on arbitrary URL

### DIFF
--- a/sphinx_rtd_theme/breadcrumbs.html
+++ b/sphinx_rtd_theme/breadcrumbs.html
@@ -10,6 +10,8 @@
           <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ source_suffix }}" class="fa fa-github"> Edit on GitHub</a>
         {% elif display_bitbucket %}
           <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ source_suffix }}" class="fa fa-bitbucket"> Edit on Bitbucket</a>
+        {% elif show_source and source_url_prefix %}
+          <a href="{{ source_url_prefix }}{{ pagename }}{{ source_suffix }}">View page source</a>
         {% elif show_source and has_source and sourcename %}
           <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> View page source</a>
         {% endif %}


### PR DESCRIPTION
Currently only source code hosted on GitHub or BitBucket are supported to be linked. This PR adds the ability to link to an arbitrary source code host URL. To use it, html_show_sourcelink must be True, and source_url_prefix must be assigned to be the URL prefix.