### PR TITLE
update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "sphinx-rtd-theme",
-  "version": "1.0",
+  "version": "0.1.7",
   "homepage": "https://github.com/snide/wyrm",
   "authors": [
     "Dave Snider <dave.snider@gmail.com>"
@@ -26,7 +26,7 @@
     "tests",
     "src"
   ],
-  "dependencies": {
+  "devDependencies": {
     "wyrm": "~0.0.x"
   }
 }


### PR DESCRIPTION
1. match the version in `sphinx_rtd_them/__init__.py` file
2. use `devDependencies` instead of `dependencies`, because we don't need wyrm in production install.