### PR TITLE
Remove broken "Edit on GitHub/Bitbucket" link from search pages

### DIFF
--- a/sphinx_rtd_theme/breadcrumbs.html
+++ b/sphinx_rtd_theme/breadcrumbs.html
@@ -6,14 +6,16 @@
       {% endfor %}
     <li>{{ title }}</li>
       <li class="wy-breadcrumbs-aside">
-        {% if display_github %}
-          <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ source_suffix }}" class="fa fa-github"> Edit on GitHub</a>
-        {% elif display_bitbucket %}
-          <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ source_suffix }}" class="fa fa-bitbucket"> Edit on Bitbucket</a>
-        {% elif show_source and source_url_prefix %}
-          <a href="{{ source_url_prefix }}{{ pagename }}{{ source_suffix }}">View page source</a>
-        {% elif show_source and has_source and sourcename %}
-          <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> View page source</a>
+        {% if pagename != "search" %}
+          {% if display_github %}
+            <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ source_suffix }}" class="fa fa-github"> Edit on GitHub</a>
+          {% elif display_bitbucket %}
+            <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ source_suffix }}" class="fa fa-bitbucket"> Edit on Bitbucket</a>
+          {% elif show_source and source_url_prefix %}
+            <a href="{{ source_url_prefix }}{{ pagename }}{{ source_suffix }}">View page source</a>
+          {% elif show_source and has_source and sourcename %}
+            <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> View page source</a>
+          {% endif %}
         {% endif %}
       </li>
   </ul>


### PR DESCRIPTION
On a page of search results on ReadTheDocs, the "Edit on GitHub/Bitbucket" link tries to send the reader to a file "search.rst" or "search.txt" in the repository. Since the search results only exist as a template, this is a 404'd link.

This change to the template means that the "Edit on GitHub/Bitbucket" link is not shown on search pages, getting rid of this broken link.

---

The only change is the new if/endif block; the other changed lines are just matching indentation.