### PR TITLE
Change highlighted right-left padding to 1px

### DIFF
--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -141,7 +141,7 @@
     background: $yellow
     display: inline-block
     font-weight: bold
-    padding: 0 $base-line-height / 4
+    padding: 0 1px
 
   // These are the little citation links [1] that show up within paragraphs.
   .footnote-reference, .citation-reference


### PR DESCRIPTION
This was previously set to 6px, making it look like there were spaces between
the highlighted text and non-highlighted text. In my opinion, it looks better and
the highlight is less obtrusive when this is set to 1px.