### PR TITLE
Don't show scrollbar if there's nothing to scroll

### DIFF
--- a/sass/_theme_layout.sass
+++ b/sass/_theme_layout.sass
@@ -252,8 +252,7 @@
   left: 0
   padding-bottom: 2em
   width: $nav-desktop-width
-  overflow-x: hidden
-  overflow-y: scroll
+  overflow: auto
   min-height: 100%
   background: $menu-background-color
   z-index: $z-index-popover


### PR DESCRIPTION
Fix #200

Only tested with Firebug, didn't bother to install SASS.