### PR TITLE
Add theme option for collapsing the nav.

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -107,7 +107,7 @@
 
       <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
         {% block menu %}
-          {% set toctree = toctree(maxdepth=4, collapse=False, includehidden=True) %}
+          {% set toctree = toctree(maxdepth=4, collapse=theme_collapse_navigation, includehidden=True) %}
           {% if toctree %}
               {{ toctree }}
           {% else %}

--- a/sphinx_rtd_theme/theme.conf
+++ b/sphinx_rtd_theme/theme.conf
@@ -7,4 +7,4 @@ typekit_id = hiw1hhg
 analytics_id = 
 sticky_navigation = False
 logo_only =
-collapse_navigation = True
+collapse_navigation = False

--- a/sphinx_rtd_theme/theme.conf
+++ b/sphinx_rtd_theme/theme.conf
@@ -7,3 +7,4 @@ typekit_id = hiw1hhg
 analytics_id = 
 sticky_navigation = False
 logo_only =
+collapse_navigation = True


### PR DESCRIPTION
This defaults to on,
because many use cases don't have large navs and want to see them all.
However,
it can be a large speedup for large docsets