### PR TITLE
Fix Safari over-scroll bug, fixes #218

### DIFF
--- a/sphinx_rtd_theme/static/js/theme.js
+++ b/sphinx_rtd_theme/static/js/theme.js
@@ -49,29 +49,30 @@ window.SphinxRtdTheme = (function (jquery) {
         var navBar,
             win,
             winScroll = false,
+            winResize = false,
             linkScroll = false,
             winPosition = 0,
+            winHeight,
+            docHeight,
             enable = function () {
                 init();
                 reset();
                 win.on('hashchange', reset);
 
-                // Set scrolling
+                // Set scroll monitor
                 win.on('scroll', function () {
                     if (!linkScroll) {
                         winScroll = true;
                     }
                 });
-                setInterval(function () {
-                    if (winScroll) {
-                        winScroll = false;
-                        var newWinPosition = win.scrollTop(),
-                            navPosition = navBar.scrollTop(),
-                            newNavPosition = navPosition + (newWinPosition - winPosition);
-                        navBar.scrollTop(newNavPosition);
-                        winPosition = newWinPosition;
-                    }
-                }, 25);
+                setInterval(function () { if (winScroll) scroll(); }, 25);
+
+                // Set resize monitor
+                win.on('resize', function () {
+                    winResize = true;
+                });
+                setInterval(function () { if (winResize) resize(); }, 25);
+                resize();
             },
             init = function () {
                 navBar = jquery('nav.wy-nav-side:first');
@@ -94,6 +95,23 @@ window.SphinxRtdTheme = (function (jquery) {
                         console.log("Error expanding nav for anchor", err);
                     }
                 }
+            },
+            scroll = function () {
+                winScroll = false;
+                var newWinPosition = win.scrollTop(),
+                    winBottom = newWinPosition + winHeight,
+                    navPosition = navBar.scrollTop(),
+                    newNavPosition = navPosition + (newWinPosition - winPosition);
+                if (newWinPosition < 0 || winBottom > docHeight) {
+                    return;
+                }
+                navBar.scrollTop(newNavPosition);
+                winPosition = newWinPosition;
+            },
+            resize = function () {
+                winResize = false;
+                winHeight = win.height();
+                docHeight = $(document).height();
             },
             hashChange = function () {
                 linkScroll = true;


### PR DESCRIPTION
Protect against negative scroll values or scroll values past the end of the
document. Stop scrolling if this is the case.