### PR TITLE
Allow setting the nav header color via config

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -85,7 +85,7 @@
 
     {# SIDE NAV, TOGGLES ON MOBILE #}
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
-      <div class="wy-side-nav-search">
+      <div class="wy-side-nav-search"{% if theme_nav_header_color %} style="background-color:{{ theme_nav_header_color }};"{% endif %}>
         {% block sidebartitle %}
 
         {% if logo and theme_logo_only %}


### PR DESCRIPTION
If you have a collection of related, but distinct doc sites, it's really nice to be able to color code them without having a completely custom theme for each.