### PR TITLE
insert courtesy newline to <pre> elements

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -192,5 +192,7 @@
 
   {%- block footer %} {% endblock %}
 
+  <script src="{{ pathto('_static/js/util.js', 1) }}"></script>
+  <script type="text/javascript">processPre();</script>
 </body>
 </html>

--- a/sphinx_rtd_theme/static/js/util.js
+++ b/sphinx_rtd_theme/static/js/util.js
@@ -1,0 +1,39 @@
+// activate a courtesy newline at end of pre to allow copy-paste
+var processPre = function()
+{
+  var pres = document.getElementsByTagName("pre");
+  for (var i = 0; i < pres.length; ++i) {
+      var pre = pres[i];
+      pre.onmouseenter = function (e) {
+          var childCount = e.srcElement.children.length;
+          // if not already processed
+          if (childCount == 0 || e.srcElement.children.item(childCount - 1).innerText != " ") {
+              var divWidth = e.srcElement.parentElement.clientWidth;
+              // if scrollbar is active
+              if (e.srcElement.scrollWidth > divWidth) {
+                  var lines = e.srcElement.innerText.split("\n");
+                  var maxLineLength = 0;
+                  for (var j = 0; j < lines.length; ++j) maxLineLength = Math.max(maxLineLength, lines[j].length);
+                  var lastLineLength = lines[lines.length - 1].length;
+
+                  // if last line overflow the current view, add courtesy blank line to allow selection
+                  if (lastLineLength / maxLineLength >= divWidth / e.srcElement.scrollWidth) {
+                      var p = document.createElement("p");
+                      p.innerHTML = " ";
+                      e.srcElement.appendChild(p);
+                  }
+              }
+          }
+      }
+
+      pre.onmouseleave = function (e) {
+          var childCount = e.srcElement.children.length;
+          // if already processed
+          if (childCount > 0 && e.srcElement.children.item(childCount - 1).innerText == " ") {
+              e.srcElement.removeChild(e.srcElement.children.item(childCount - 1));
+          }
+      }
+  }
+}
+
+processPre();


### PR DESCRIPTION
I added a courtesy newline to pre elements when last line overflow the view with scrollbar.
![courtesy-newline](https://cloud.githubusercontent.com/assets/13405008/10555466/18b6a2f4-7470-11e5-99f3-d4a3ea1c1700.png)

I would to know if there are a way to enable a "copy to clipboard" button for generated pre elements. I'm not an expert in javascript but I suspect the select-all text or the copy to clipboard can work in some browser and in others not.

How it works:
- entering the pre element if last line overflow the view a pre space element is inserted to allow easy select
- when mouse goes out the pre is removed.

Optionally ( not yet implemented ) :
- enable of the feature in the layout.html through a config variable
- disable the auto-removal of the pre element if previously inserted ( to avoid too much movements of the page content ) when the mouse exits the pre content.


