### PR TITLE
Add a body_begin block at the start of <body>

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -81,6 +81,8 @@
 
 <body class="wy-body-for-nav" role="document">
 
+  {% block body_begin %}
+  {% endblock %}
   <div class="wy-grid-for-nav">
 
     {# SIDE NAV, TOGGLES ON MOBILE #}


### PR DESCRIPTION
This makes it easy to add a cookie banner or similar at the top of the
page, particularly when JS is disabled and you can't insert the banner
dynamically.