### PR TITLE
Add support for canonical URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,15 @@ In your ``conf.py`` file:
 
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
+You may also specify a canonical url in conf.py to let search engines know
+they should give higher ranking to latest version of the docs:
+
+.. code:: python
+
+    html_theme_options['canonical_url'] = 'http://domain.tld/latest/docs/'
+
+The url points to the root of the documentation. It requires a trailing slash.
+
 Via git or download
 -------------------
 

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -22,6 +22,10 @@
   {% if favicon %}
     <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
   {% endif %}
+  {# CANONICAL URL #}
+  {% if theme_canonical_url %}
+    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html"/>
+  {% endif %}
 
   {# CSS #}
 

--- a/sphinx_rtd_theme/layout_old.html
+++ b/sphinx_rtd_theme/layout_old.html
@@ -125,6 +125,9 @@
     {%- if favicon %}
     <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
     {%- endif %}
+    {%- if theme_canonical_url %}
+    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html"/>
+    {%- endif %}
     {%- endif %}
 {%- block linktags %}
     {%- if hasdoc('about') %}

--- a/sphinx_rtd_theme/theme.conf
+++ b/sphinx_rtd_theme/theme.conf
@@ -4,8 +4,9 @@ stylesheet = css/theme.css
 
 [options]
 typekit_id = hiw1hhg
-analytics_id = 
+analytics_id =
 sticky_navigation = False
 logo_only =
 collapse_navigation = False
 display_version = True
+canonical_url =


### PR DESCRIPTION
I took this from MongoEngine's embedded version of sphinx_rtd_theme.

It is pretty much the same as https://github.com/Pylons/pylons_sphinx_theme/pull/8.

Like it says:

> Adds a canonical URL to each page for a better google search result (in the future). Outdated documentation versions should no longer come as first entry in search results.

Please ask for a rework it this is interesting but not satisfying as it is.