### PR TITLE
Change README.rst code order of conf.d 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,9 +45,9 @@ In your ``conf.py`` file:
 
     import sphinx_rtd_theme
 
-    html_theme = "sphinx_rtd_theme"
-
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+    
+    html_theme = "sphinx_rtd_theme"
 
 Via git or download
 -------------------


### PR DESCRIPTION
Change the order of two lines.
`html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]`

`html_theme = "sphinx_rtd_theme"`

It could return error when .get_html_theme_path() method called later than theme assignment like below.

`Theme error:`

`no theme named 'sphinx_rtd_theme`' found (missing theme.conf?)`

`make: *** [html] Error 1`