### PR TITLE
Fix #258: Avoid large logo to overflow

### DIFF
--- a/sass/_theme_layout.sass
+++ b/sass/_theme_layout.sass
@@ -196,6 +196,7 @@
     display: inline-block
     padding: $base-line-height / 6 $base-line-height / 4
     margin-bottom: $gutter / 2
+    width: 100%
     +font-smooth
     &:hover
       background: rgba(255,255,255,.1)


### PR DESCRIPTION
Hi,

I am having the same issue as in #258 (in my case the logo is in SVG format and used at multiple place, so it is not relevant to create a resized version of the file).

However I suggest a subtle different change than @vlttnv as setting `img.logo` to 100% will enlarge small images and make them ugly-looking.
