### PR TITLE
Fix versions.html for non-rtfd instances.

### DIFF
--- a/sphinx_rtd_theme/versions.html
+++ b/sphinx_rtd_theme/versions.html
@@ -9,8 +9,8 @@
     <div class="rst-other-versions">
       <dl>
         <dt>Versions</dt>
-        {% for slug, url in versions %}
-          <dd><a href="{{ url }}">{{ slug }}</a></dd>
+        {% for version in versions %}
+          <dd><a href="{{ version.get_absolute_url }}">{{ version.slug }}</a></dd>
         {% endfor %}
       </dl>
       <dl>


### PR DESCRIPTION
I have a RTD server running internally and this theme has a problem navigating to different versions of the docs. I believe that this problem has existed for a while, but has gone unnoticed due to readthedocs.org gives each project a subdomain on readthedocs.io so it has gone unnoticed. More details in the commit message.

I did run `grunt` and `grunt build`, but nothing new was generated.

### Commit Message

```
It appears that the template variable `versions` must have changed at
some point (or else, this code was never "correct").

As is, the href produced from "url" is "/en/latest/". This works for
projects on readthedocs.org because the resulting url uses the project
subdomain http://project-name.readthedocs.io/en/some-ver/.

However, this does not work for privately managed rtfd servers where
projects do not have project-specific subdomains. So, the resulting href
produced is http://rtd.private-company.tld/en/some-ver/ when it
should be http://rtd.private-company.tld/docs/project-name/en/some-ver/.

I had a look in the rtfd/readthedocs.org project for a solution. I found
a few instances, like readthedocs/templates/core/project_details.html,
that use a `for version in versions` block with the href produced by
`version.get_absolute_url` and the slug comes from `version.slug`.
```