### PR TITLE
Fix spacing in pre

### DIFF
--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -19,6 +19,9 @@
     max-width: 100%
     height: auto !important
 
+  .highlight > pre
+    line-height: normal
+
   div.figure
     margin-bottom: $base-line-height
     p.caption


### PR DESCRIPTION
Now it looks like this:
![1](https://cloud.githubusercontent.com/assets/2155800/20665266/67b0a6ee-b578-11e6-98b9-76ae20cbf430.png)
c.f. with #329.

Could you review also #335?  Theme is broken on py3 without this patch.
