### PR TITLE
Add missing SOURCELINK_SUFFIX

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -170,7 +170,8 @@
             VERSION:'{{ release|e }}',
             COLLAPSE_INDEX:false,
             FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
-            HAS_SOURCE:  {{ has_source|lower }}
+            HAS_SOURCE:  {{ has_source|lower }},
+            SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
         };
     </script>
     {%- for scriptfile in script_files %}

--- a/sphinx_rtd_theme/layout_old.html
+++ b/sphinx_rtd_theme/layout_old.html
@@ -91,7 +91,8 @@
         VERSION:     '{{ release|e }}',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
-        HAS_SOURCE:  {{ has_source|lower }}
+        HAS_SOURCE:  {{ has_source|lower }},
+        SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
       };
     </script>
     {%- for scriptfile in script_files %}


### PR DESCRIPTION
Adds `DOCUMENTATION_OPTIONS.SOURCELINK_SUFFIX` which is expected by `searchtools.js_t`

Related sphinx commit: https://github.com/sphinx-doc/sphinx/commit/71dd8bfbf94417ad55b2444e1dbd219db266f335

I'm using sphinx 1.5-1 and without this fix, search doesn't work:

```
Uncaught TypeError: Cannot read property 'length' of undefined
    at displayNextItem (searchtools.js:543)
    at Object.query (searchtools.js:574)
    at Object.setIndex (searchtools.js:362)
    at <anonymous>:1:8
    at p (jquery.js:2)
    at Function.globalEval (jquery.js:2)
    at text script (jquery.js:4)
    at Nb (jquery.js:4)
    at A (jquery.js:4)
    at XMLHttpRequest.<anonymous> (jquery.js:4)
```