### PR TITLE
Add comments block which can be overriden

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,11 @@ You can currently add the following:
 Changelog
 =========
 
+master
+------
+
+* Adds the ``comments`` block after the ``body`` block in the template
+
 v0.1.10-alpha
 -------------
 

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -152,6 +152,9 @@
            <div itemprop="articleBody">
             {% block body %}{% endblock %}
            </div>
+           <div class="articleComments">
+            {% block comments %}{% endblock %}
+           </div>
           </div>
           {% include "footer.html" %}
         </div>


### PR DESCRIPTION
With this new block I was able to override the theme and add a Disqus comments section on http://mutation-testing-patterns.readthedocs.io/en/latest/. Scroll at the bottom to see how it looks.