### PR TITLE
Display the toctree conditionally

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -121,12 +121,14 @@
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
           {% block menu %}
-            {% set toctree = toctree(maxdepth=theme_navigation_depth|int, collapse=theme_collapse_navigation, includehidden=True) %}
-            {% if toctree %}
-                {{ toctree }}
-            {% else %}
-                <!-- Local TOC -->
-                <div class="local-toc">{{ toc }}</div>
+            {% if display_toc %}
+              {% set toctree = toctree(maxdepth=theme_navigation_depth|int, collapse=theme_collapse_navigation, includehidden=True) %}
+              {% if toctree %}
+                  {{ toctree }}
+              {% else %}
+                  <!-- Local TOC -->
+                  <div class="local-toc">{{ toc }}</div>
+              {% endif %}
             {% endif %}
           {% endblock %}
         </div>


### PR DESCRIPTION
The `singlehtml` builder for sphinx doesn't produce a toctree, and was throwing
an exception on these builds. This makes use of the `display_toc` context
variable, used back to at least `sphinx==1.1`.

This fixes rtfd/readthedocs.org#2398 and friends