### PR TITLE
Fix problem triggered by unconditional toctree call and empty toctree

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,17 @@ Changelog
 master
 ------
 
+v0.2.3
+------
+
+* Temporarily patch Sphinx issue with ``singlehtml`` builder by inspecting the
+  builder in template.
+
+v0.2.2
+------
+
+* Roll back toctree fix in 0.2.1 (#367). This didn't fix the issue and
+  introduced another bug with toctrees display.
 
 v0.2.1
 ------

--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -5,7 +5,7 @@ From https://github.com/ryan-roemer/sphinx-bootstrap-theme.
 """
 import os
 
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 __version_full__ = __version__
 
 

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -125,12 +125,18 @@
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
           {% block menu %}
-            {% set toctree = toctree(maxdepth=theme_navigation_depth|int, collapse=theme_collapse_navigation, includehidden=True) %}
-            {% if toctree %}
-                {{ toctree }}
+            {#
+              The singlehtml builder doesn't handle this toctree call when the
+              toctree is empty. Skip building this for now.
+            #}
+            {% if builder != 'singlehtml' %}
+              {% set global_toc = toctree(maxdepth=theme_navigation_depth|int, collapse=theme_collapse_navigation, includehidden=True) %}
+            {% endif %}
+            {% if global_toc %}
+              {{ global_toc }}
             {% else %}
-                <!-- Local TOC -->
-                <div class="local-toc">{{ toc }}</div>
+              <!-- Local TOC -->
+              <div class="local-toc">{{ toc }}</div>
             {% endif %}
           {% endblock %}
         </div>


### PR DESCRIPTION
This bumps to v0.2.3

Refs rtfd/readthedocs.org#2398